### PR TITLE
Fix integer truncating issue in fan percentages

### DIFF
--- a/src/ui/components/ui_comp_temperaturecomponent.c
+++ b/src/ui/components/ui_comp_temperaturecomponent.c
@@ -296,7 +296,7 @@ void ui_temperatureComponent_onXtouchPartFanSpeed(lv_event_t *e)
     struct XTOUCH_MESSAGE_DATA *message = (struct XTOUCH_MESSAGE_DATA *)m->payload;
     char value[3];
 
-    itoa(message->data * 100 / 255, value, 10);
+    itoa(round(message->data * 100 / 255.), value, 10);
     lv_textarea_set_text(target, value);
 }
 
@@ -308,7 +308,7 @@ void ui_temperatureComponent_onXtouchAuxFanSpeed(lv_event_t *e)
     struct XTOUCH_MESSAGE_DATA *message = (struct XTOUCH_MESSAGE_DATA *)m->payload;
     char value[3];
 
-    itoa(message->data * 100 / 255, value, 10);
+    itoa(round(message->data * 100 / 255.), value, 10);
     lv_textarea_set_text(target, value);
 }
 
@@ -320,7 +320,7 @@ void ui_temperatureComponent_onXtouchChamberFanSpeed(lv_event_t *e)
     struct XTOUCH_MESSAGE_DATA *message = (struct XTOUCH_MESSAGE_DATA *)m->payload;
     char value[4];
 
-    itoa(message->data * 100 / 255, value, 10);
+    itoa(round(message->data * 100 / 255.), value, 10);
     lv_textarea_set_text(target, value);
 }
 


### PR DESCRIPTION
Hi, I made a quick fix after I noticed that fan percentages always appeared off by one. I did some quick testing, seems to resolve the issue, but feel free to test it as well or suggest a better way if this one is not optimal.

Thanks for the good work.